### PR TITLE
Don't merge back before traversing the additional_conf; close #17

### DIFF
--- a/lib/arethusa/cli.rb
+++ b/lib/arethusa/cli.rb
@@ -269,8 +269,8 @@ EOF
             additional_conf = read_conf(value)
             conf.delete(key)
             if additional_conf
-              conf.merge!(additional_conf)
               traverse(additional_conf)
+              conf.merge!(additional_conf)
             end
           end
         end


### PR DESCRIPTION
The [traverse function in cli.rb](https://github.com/alpheios-project/arethusa-cli/blob/master/lib/arethusa/cli.rb#L263) merged back before loading all of the higher-level @includes. Somehow the [additional step for wrapped @includes](https://github.com/alpheios-project/arethusa-cli/blob/master/lib/arethusa/cli.rb#L267) remedied this.